### PR TITLE
Fix window decorations appearing off-screen

### DIFF
--- a/openbox-window-snap.diff
+++ b/openbox-window-snap.diff
@@ -14,7 +14,7 @@ index 11a01400..a69c25ec 100644
      gboolean skip_pager;
      /*! The window should not be displayed by taskbars */
 diff --git a/openbox/moveresize.c b/openbox/moveresize.c
-index d12a64de..1a2c40b3 100644
+index d12a64de..bed912c5 100644
 --- a/openbox/moveresize.c
 +++ b/openbox/moveresize.c
 @@ -372,7 +372,7 @@ void moveresize_end(gboolean cancel)
@@ -26,7 +26,7 @@ index d12a64de..1a2c40b3 100644
  
      if (keyboard) resist = keydist - 1; /* resist for one key press */
      else resist = config_resist_win;
-@@ -380,6 +380,69 @@ static void do_move(gboolean keyboard, gint keydist)
+@@ -380,6 +380,71 @@ static void do_move(gboolean keyboard, gint keydist)
      if (!keyboard) resist = config_resist_edge;
      resist_move_monitors(moveresize_client, resist, &cur_x, &cur_y);
  
@@ -56,13 +56,15 @@ index d12a64de..1a2c40b3 100644
 +        moveresize_client->pre_max_area.y = cur_y;
 +        moveresize_client->pre_max_area.width = cur_w;
 +        moveresize_client->pre_max_area.height = cur_h;
++        client_maximize(moveresize_client, TRUE, 2);
 +        moveresize_client->snapped_left = TRUE;
 +    }
-+    else if (x > 0 && moveresize_client->snapped_left && !moveresize_client->max_horz && !moveresize_client->max_vert) {
++    else if (x > 0 && moveresize_client->snapped_left && !moveresize_client->max_horz) {
 +        cur_x = moveresize_client->pre_max_area.x;
 +        cur_y = moveresize_client->pre_max_area.y;
 +        cur_w = moveresize_client->pre_max_area.width;
 +        cur_h = moveresize_client->pre_max_area.height;
++        client_maximize(moveresize_client, FALSE, 2);
 +        moveresize_client->snapped_left = FALSE;
 +    }
 +    else if (x == width && !moveresize_client->snapped_right && !moveresize_client->max_horz && !moveresize_client->max_vert) {
@@ -70,13 +72,15 @@ index d12a64de..1a2c40b3 100644
 +        moveresize_client->pre_max_area.y = cur_y;
 +        moveresize_client->pre_max_area.width = cur_w;
 +        moveresize_client->pre_max_area.height = cur_h;
++        client_maximize(moveresize_client, TRUE, 2);
 +        moveresize_client->snapped_right = TRUE;
 +    }
-+    else if (x < width && moveresize_client->snapped_right && !moveresize_client->max_horz && !moveresize_client->max_vert) {
++    else if (x < width && moveresize_client->snapped_right && !moveresize_client->max_horz) {
 +        cur_x = moveresize_client->pre_max_area.x;
 +        cur_y = moveresize_client->pre_max_area.y;
 +        cur_w = moveresize_client->pre_max_area.width;
 +        cur_h = moveresize_client->pre_max_area.height;
++        client_maximize(moveresize_client, FALSE, 2);
 +        moveresize_client->snapped_right = FALSE;
 +    }
 +
@@ -84,13 +88,11 @@ index d12a64de..1a2c40b3 100644
 +        cur_x = 0;
 +        cur_y = 0;
 +        cur_w = (width / 2) - 1;
-+        cur_h = height;
 +    }
 +    else if (moveresize_client->snapped_right) {
 +        cur_x = width / 2;
 +        cur_y = 0;
 +        cur_w = width / 2;
-+        cur_h = height;
 +    }
 +
      client_configure(moveresize_client, cur_x, cur_y, cur_w, cur_h,


### PR DESCRIPTION
This commit fixes #1 by using the client_maximize function to vertically maximize the window.